### PR TITLE
Add Repeat Mode config items

### DIFF
--- a/custom_components/vikunja/__init__.py
+++ b/custom_components/vikunja/__init__.py
@@ -15,7 +15,9 @@ PLATFORMS = [
     Platform.DATETIME,
     Platform.BUTTON,
     Platform.SELECT,
-    Platform.NUMBER]
+    Platform.NUMBER,
+    Platform.SWITCH
+]
 
 
 async def async_setup_entry(hass, entry):

--- a/custom_components/vikunja/__init__.py
+++ b/custom_components/vikunja/__init__.py
@@ -9,7 +9,13 @@ from pyvikunja.api import VikunjaAPI
 from .const import DOMAIN, CONF_BASE_URL, CONF_TOKEN, LOGGER, CONF_SECS_INTERVAL
 from .coordinator import VikunjaDataUpdateCoordinator
 
-PLATFORMS = [Platform.SENSOR, Platform.BINARY_SENSOR, Platform.DATETIME, Platform.BUTTON]
+PLATFORMS = [
+    Platform.SENSOR,
+    Platform.BINARY_SENSOR,
+    Platform.DATETIME,
+    Platform.BUTTON,
+    Platform.SELECT,
+    Platform.NUMBER]
 
 
 async def async_setup_entry(hass, entry):

--- a/custom_components/vikunja/manifest.json
+++ b/custom_components/vikunja/manifest.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "documentation": "https://github.com/joeShuff/vikunja-homeassistant",
   "codeowners": ["@joeShuff"],
-  "requirements": ["pyvikunja==0.11"],
+  "requirements": ["pyvikunja==0.14"],
   "config_flow": true,
   "integration_type": "service",
   "iot_class": "local_polling"

--- a/custom_components/vikunja/manifest.json
+++ b/custom_components/vikunja/manifest.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "documentation": "https://github.com/joeShuff/vikunja-homeassistant",
   "codeowners": ["@joeShuff"],
-  "requirements": ["pyvikunja==0.8"],
+  "requirements": ["pyvikunja==0.9"],
   "config_flow": true,
   "integration_type": "service",
   "iot_class": "local_polling"

--- a/custom_components/vikunja/manifest.json
+++ b/custom_components/vikunja/manifest.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "documentation": "https://github.com/joeShuff/vikunja-homeassistant",
   "codeowners": ["@joeShuff"],
-  "requirements": ["pyvikunja==0.9"],
+  "requirements": ["pyvikunja==0.11"],
   "config_flow": true,
   "integration_type": "service",
   "iot_class": "local_polling"

--- a/custom_components/vikunja/number.py
+++ b/custom_components/vikunja/number.py
@@ -1,0 +1,39 @@
+from pyvikunja.api import VikunjaAPI
+
+from custom_components.vikunja import LOGGER
+from custom_components.vikunja.const import DATA_TASKS_KEY
+from custom_components.vikunja.sensors.task.repeat_mode_sensors import VikunjaRepeatIntervalSizeSensor
+
+
+def get_number_for_task(coordinator, base_url, task_id):
+    return [
+        VikunjaRepeatIntervalSizeSensor(coordinator, base_url, task_id),
+    ]
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    LOGGER.info("Setting up Vikunja number entities...")
+
+    # Get stored API instance and fetched data
+    vikunja_data = hass.data.get("vikunja", {}).get(entry.entry_id)
+    if not vikunja_data:
+        LOGGER.error("No Vikunja data found in hass.data")
+        return False
+
+    vikunja_api: VikunjaAPI = vikunja_data["api"]
+    coordinator = vikunja_data["coordinator"]
+
+    # Create sensor entities
+    entities = []
+
+    tasks = coordinator.data[DATA_TASKS_KEY].keys()
+
+    for task_id in tasks:
+        LOGGER.info(f"Task is {task_id}")
+        entities.extend(get_number_for_task(coordinator, vikunja_api.web_ui_link, task_id))
+
+    if not entities:
+        LOGGER.warning("No number entities created")
+
+    async_add_entities(entities, True)
+    LOGGER.info(f"Added {len(entities)} Vikunja number entities.")

--- a/custom_components/vikunja/select.py
+++ b/custom_components/vikunja/select.py
@@ -1,0 +1,40 @@
+from pyvikunja.api import VikunjaAPI
+
+from custom_components.vikunja import LOGGER
+from custom_components.vikunja.const import DATA_TASKS_KEY
+from custom_components.vikunja.sensors.task.repeat_mode_sensors import *
+
+
+def get_select_for_task(coordinator, base_url, task_id):
+    return [
+        VikunjaRepeatModeSelect(coordinator, base_url, task_id),
+        VikunjaRepeatIntervalUnitSensor(coordinator, base_url, task_id)
+    ]
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    LOGGER.info("Setting up Vikunja selects...")
+
+    # Get stored API instance and fetched data
+    vikunja_data = hass.data.get("vikunja", {}).get(entry.entry_id)
+    if not vikunja_data:
+        LOGGER.error("No Vikunja data found in hass.data")
+        return False
+
+    vikunja_api: VikunjaAPI = vikunja_data["api"]
+    coordinator = vikunja_data["coordinator"]
+
+    # Create sensor entities
+    entities = []
+
+    tasks = coordinator.data[DATA_TASKS_KEY].keys()
+
+    for task_id in tasks:
+        LOGGER.info(f"Task is {task_id}")
+        entities.extend(get_select_for_task(coordinator, vikunja_api.web_ui_link, task_id))
+
+    if not entities:
+        LOGGER.warning("No entities created")
+
+    async_add_entities(entities, True)
+    LOGGER.info(f"Added {len(entities)} Vikunja selects.")

--- a/custom_components/vikunja/sensors/TaskSensors.py
+++ b/custom_components/vikunja/sensors/TaskSensors.py
@@ -242,7 +242,7 @@ class VikunjaTaskStartDateSensor(VikunjaTaskEntity, DateTimeEntity):
     async def async_set_value(self, value):
         LOGGER.info(f"Setting {self.name} to {value}")
         await self.task.set_start_date(value)
-        await self.async_update()
+        await self.update_task()
 
     @property
     def unique_id(self) -> str:
@@ -273,7 +273,7 @@ class VikunjaTaskEndDateSensor(VikunjaTaskEntity, DateTimeEntity):
     async def async_set_value(self, value):
         LOGGER.info(f"Setting {self.name} to {value}")
         await self.task.set_end_date(value)
-        await self.async_update()
+        await self.update_task()
 
     @property
     def unique_id(self) -> str:
@@ -291,7 +291,7 @@ class VikunjaTaskCompleteButton(VikunjaTaskEntity, ButtonEntity):
         LOGGER.info(f"Marking task {self.task.title} as done...")
         await self.task.mark_as_done()  # Mark task as done via API
 
-        await self.async_update()
+        await self.update_task()
 
     @property
     def name(self):

--- a/custom_components/vikunja/sensors/task/repeat_mode_sensors.py
+++ b/custom_components/vikunja/sensors/task/repeat_mode_sensors.py
@@ -8,6 +8,7 @@ from homeassistant.components.switch import SwitchEntity
 from pyvikunja.models.enum.repeat_mode import RepeatMode
 from pyvikunja.models.task import Task
 
+from custom_components.vikunja import LOGGER
 from custom_components.vikunja.sensors.vikunja_task_entity import VikunjaTaskEntity
 
 
@@ -74,12 +75,12 @@ class VikunjaRepeatModeEnabledSwitch(VikunjaTaskEntity, SwitchEntity):
     async def async_turn_on(self, **kwargs):
         """Turn on repeat mode."""
         await self.task.set_repeating_enabled(True)  # Update task to enable repeat mode
-        await self.async_update()
+        await self.update_task()
 
     async def async_turn_off(self, **kwargs):
         """Turn off repeat mode."""
         await self.task.set_repeating_enabled(False)  # Update task to disable repeat mode
-        await self.async_update()
+        await self.update_task()
 
     @property
     def name(self):
@@ -119,7 +120,7 @@ class VikunjaRepeatModeSelect(VikunjaTaskEntity, SelectEntity):
         """Handle user selection of a new repeat mode."""
         mode_value = next((k for k, v in REPEAT_MODE_OPTIONS.items() if v == option), None)
         await self.task.set_repeating_interval(mode=RepeatMode(mode_value))
-        await self.async_update()
+        await self.update_task()
 
     @property
     def name(self):
@@ -155,7 +156,7 @@ class VikunjaRepeatIntervalSizeSensor(VikunjaTaskEntity, NumberEntity):
 
         # Send update
         await self.task.set_repeating_interval(interval=timedelta(seconds=new_value))
-        await self.async_update()
+        await self.update_task()
 
     @property
     def name(self):
@@ -254,7 +255,7 @@ class VikunjaRepeatIntervalUnitSensor(VikunjaTaskEntity, SelectEntity):
 
         # Send update
         await self.task.set_repeating_interval(interval=timedelta(seconds=new_value))
-        await self.async_update()
+        await self.update_task()
 
     @property
     def available(self) -> bool:

--- a/custom_components/vikunja/sensors/task/repeat_mode_sensors.py
+++ b/custom_components/vikunja/sensors/task/repeat_mode_sensors.py
@@ -1,0 +1,217 @@
+from datetime import timedelta
+from enum import Enum
+
+from homeassistant.components.number import NumberEntity, NumberMode
+from homeassistant.components.select import SelectEntity
+from pyvikunja.models.enum.repeat_mode import RepeatMode
+from pyvikunja.models.task import Task
+
+from custom_components.vikunja.sensors.vikunja_task_entity import VikunjaTaskEntity
+
+
+def get_repeat_info_for_task(task: Task) -> tuple['RepeatUnit', int]:
+    """Returns the repeat unit and repeat interval from a Task."""
+    if task.repeat_after is None or task.repeat_after.total_seconds() <= 0:
+        return RepeatUnit.DAYS, 1  # Default to 1 day if not set
+
+    unit = RepeatUnit.from_seconds(int(task.repeat_after.total_seconds()))
+    scaled_value = int(int(task.repeat_after.total_seconds()) / unit.seconds)
+
+    return unit, scaled_value
+
+
+class RepeatUnit(Enum):
+    HOURS = (3600, "Hours")  # 1 Hour = 3600 seconds
+    DAYS = (86400, "Days")  # 1 Day = 86400 seconds
+    WEEKS = (604800, "Weeks")  # 1 Week = 604800 seconds
+
+    def __init__(self, seconds: int, display: str):
+        self.seconds = seconds
+        self.display = display
+
+    @classmethod
+    def list_display_values(cls) -> list[str]:
+        """Returns a list of display names for the UI dropdown."""
+        return [unit.display for unit in cls]
+
+    @classmethod
+    def from_seconds(cls, seconds: int) -> 'RepeatUnit':
+        """Determine the best unit and return the unit"""
+        if seconds % RepeatUnit.WEEKS.seconds == 0:
+            return RepeatUnit.WEEKS
+        elif seconds % RepeatUnit.DAYS.seconds == 0:
+            return RepeatUnit.DAYS
+        else:
+            return RepeatUnit.HOURS
+
+    @classmethod
+    def from_display(cls, display: str) -> 'RepeatUnit':
+        """Get the RepeatUnit from its display string."""
+        for unit in cls:
+            if unit.display.lower() == display.lower():
+                return unit
+        raise ValueError(f"Invalid repeat unit: {display}")
+
+
+REPEAT_MODE_OPTIONS = {
+    RepeatMode.DEFAULT: "Default",
+    RepeatMode.MONTHLY: "Monthly",
+    RepeatMode.FROM_CURRENT_DATE: "From Current Date"
+}
+
+
+class VikunjaRepeatModeSelect(VikunjaTaskEntity, SelectEntity):
+    """Select entity for Vikunja task repeat mode."""
+
+    def __init__(self, coordinator, base_url, task_id):
+        """Initialize the select entity."""
+        super().__init__(coordinator, base_url, task_id)
+
+    @property
+    def options(self):
+        return list(REPEAT_MODE_OPTIONS.values())
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return REPEAT_MODE_OPTIONS.get(self.task.repeat_mode, "None")
+
+    async def async_select_option(self, option: str):
+        """Handle user selection of a new repeat mode."""
+        mode_value = next((k for k, v in REPEAT_MODE_OPTIONS.items() if v == option), None)
+        await self.task.set_repeating_interval(mode=RepeatMode(mode_value))
+        await self.async_update()
+
+    @property
+    def name(self):
+        return f"{self.name_prefix()} Repeat Mode"
+
+    @property
+    def icon(self):
+        """Icon for the sensor."""
+        return "mdi:repeat"
+
+    @property
+    def unique_id(self) -> str:
+        return self.id_prefix() + "_repeat_mode"
+
+
+class VikunjaRepeatIntervalSizeSensor(VikunjaTaskEntity, NumberEntity):
+    """Sensor entity for Vikunja task repeat interval."""
+
+    def __init__(self, coordinator, base_url, task_id):
+        """Initialize the sensor."""
+        super().__init__(coordinator, base_url, task_id)
+
+    async def async_set_value(self, value: float) -> None:
+        # Get the tasks current repeat unit and value
+        current_unit, current_value = get_repeat_info_for_task(self.task)
+
+        # Calculate the new repeat interval with the current value * new unit scale
+        # e.g. 4 Days -> Change 4 to 8 -> calculate 8 * seconds in a day
+        new_value = value * current_unit.seconds
+
+        # Send update
+        await self.task.set_repeating_interval(interval=timedelta(seconds=new_value))
+        await self.async_update()
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return f"{self.name_prefix()} Repeat Interval"
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        unit, scaled_value = get_repeat_info_for_task(self.task)
+        return scaled_value
+
+    @property
+    def max_value(self) -> float:
+        return 999999999
+
+    @property
+    def min_value(self) -> float:
+        return 1
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of the sensor."""
+        unit, scaled_value = get_repeat_info_for_task(self.task)
+        return unit.display.lower()
+
+    @property
+    def mode(self) -> NumberMode:
+        return NumberMode.BOX
+
+    @property
+    def available(self) -> bool:
+        if self.task.repeat_mode == RepeatMode.MONTHLY:
+            return False
+        else:
+            return True
+
+    @property
+    def icon(self):
+        """Icon for the sensor."""
+        return "mdi:repeat"
+
+    @property
+    def unique_id(self) -> str:
+        return self.id_prefix() + "_repeat_interval_value"
+
+
+class VikunjaRepeatIntervalUnitSensor(VikunjaTaskEntity, SelectEntity):
+    """Sensor entity for Vikunja task repeat interval unit."""
+
+    def __init__(self, coordinator, base_url, task_id):
+        """Initialize the sensor."""
+        super().__init__(coordinator, base_url, task_id)
+
+    @property
+    def options(self):
+        return RepeatUnit.list_display_values()
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return f"{self.name_prefix()} Repeat Interval Unit"
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        unit, scaled_value = get_repeat_info_for_task(self.task)
+        return unit.display
+
+    async def async_select_option(self, option: str):
+        """Handle user selection of a new repeat unit."""
+
+        # Get the new unit
+        unit = RepeatUnit.from_display(option)
+
+        # Get the tasks current repeat unit and value
+        current_unit, current_value = get_repeat_info_for_task(self.task)
+
+        # Calculate the new repeat interval with the current value * new unit scale
+        # e.g. 4 Days -> Change Days to Weeks -> calculate 4 * seconds in a week
+        new_value = current_value * unit.seconds
+
+        # Send update
+        await self.task.set_repeating_interval(interval=timedelta(seconds=new_value))
+        await self.async_update()
+
+    @property
+    def available(self) -> bool:
+        if self.task.repeat_mode == RepeatMode.MONTHLY:
+            return False
+        else:
+            return True
+
+    @property
+    def icon(self):
+        """Icon for the sensor."""
+        return "mdi:repeat"
+
+    @property
+    def unique_id(self) -> str:
+        return self.id_prefix() + "_repeat_interval_unit"

--- a/custom_components/vikunja/sensors/vikunja_task_entity.py
+++ b/custom_components/vikunja/sensors/vikunja_task_entity.py
@@ -41,3 +41,7 @@ class VikunjaTaskEntity(CoordinatorEntity):
     async def async_update(self):
         """Request an update from the coordinator."""
         await self._coordinator.async_request_refresh()
+
+    async def update_task(self):
+        """Update the coordinator's stored task data and trigger an update."""
+        self._coordinator.async_update_listeners()

--- a/custom_components/vikunja/switch.py
+++ b/custom_components/vikunja/switch.py
@@ -1,0 +1,39 @@
+from pyvikunja.api import VikunjaAPI
+
+from custom_components.vikunja.const import LOGGER
+from custom_components.vikunja.sensors.TaskSensors import *
+from custom_components.vikunja.sensors.task.repeat_mode_sensors import VikunjaRepeatModeEnabledSwitch
+
+
+def get_switch_for_task(coordinator, base_url, task_id):
+    return [
+        VikunjaRepeatModeEnabledSwitch(coordinator, base_url, task_id)
+    ]
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    LOGGER.info("Setting up Vikunja switches...")
+
+    # Get stored API instance and fetched data
+    vikunja_data = hass.data.get("vikunja", {}).get(entry.entry_id)
+    if not vikunja_data:
+        LOGGER.error("No Vikunja data found in hass.data")
+        return False
+
+    vikunja_api: VikunjaAPI = vikunja_data["api"]
+    coordinator = vikunja_data["coordinator"]
+
+    # Create sensor entities
+    entities = []
+
+    tasks = coordinator.data[DATA_TASKS_KEY].keys()
+
+    for task_id in tasks:
+        LOGGER.info(f"Task is {task_id}")
+        entities.extend(get_switch_for_task(coordinator, vikunja_api.web_ui_link, task_id))
+
+    if not entities:
+        LOGGER.warning("No entities created")
+
+    async_add_entities(entities, True)
+    LOGGER.info(f"Added {len(entities)} Vikunja switches.")


### PR DESCRIPTION
Added the ability to fetch and set repeat mode config for a task.

4 new sensors:
- Repeat Mode (Default, Monthly, Current Date)
- Repeat mode interval unit (days, weeks, months)
- Repeat mode interval value (integer value paired with the unit)
- Enabled/Disable repeat mode

![repeat_ui](https://github.com/user-attachments/assets/cdea1d7a-c650-4c65-9a16-8d37be67fd33)

