### PR TITLE
Fix exception comparing timezone aware/unaware datetimes

### DIFF
--- a/custom_components/vikunja/sensors/TaskSensors.py
+++ b/custom_components/vikunja/sensors/TaskSensors.py
@@ -4,6 +4,7 @@ from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.components.button import ButtonEntity
 from homeassistant.components.datetime import DateTimeEntity
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
+from homeassistant.util import dt
 from pyvikunja.models.enum.task_priority import Priority
 
 from custom_components.vikunja.sensors.vikunja_task_entity import *
@@ -129,8 +130,8 @@ class VikunjaTaskOverdueSensor(VikunjaTaskEntity, BinarySensorEntity):
         if not due_date:
             return False  # No due date set
 
-        # Convert due_date to a datetime object
-        now = datetime.now()
+        # Get timezone-aware datetime from HomeAssistant
+        now = dt.now()
 
         return due_date <= now
 


### PR DESCRIPTION
I've been seeing the following in logs since [the change to show times in local timezones instead of
UTC](https://github.com/joeShuff/vikunja-homeassistant/commit/ac4b09d11d28eff71a5449edaf1476f2e173b8de):

```
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 268, in _handle_refresh_interval
    await self._async_refresh(log_failures=True, scheduled=True)
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 479, in _async_refresh
    self.async_update_listeners()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 178, in async_update_listeners
    update_callback()
    ~~~~~~~~~~~~~~~^^
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 559, in _handle_coordinator_update
    self.async_write_ha_state()
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1019, in async_write_ha_state
    self._async_write_ha_state()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1141, in _async_write_ha_state
    self.__async_calculate_state()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1081, in __async_calculate_state
    state = self._stringify_state(available)
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1025, in _stringify_state
    if (state := self.state) is None:
                     ^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/binary_sensor/__init__.py", line 200, in state
    if (is_on := self.is_on) is None:
                 ^^^^^^^^^^
  File "/config/custom_components/vikunja/sensors/TaskSensors.py", line 135, in is_on
    return due_date <= now
               ^^^^^^^^^^^^^^^
TypeError: can't compare offset-naive and offset-aware datetimes
```

All overdue entities have also been unavailable. Making `now` timezone aware fixes this. I've used UTC as the timezone for current time.