### PR TITLE
fix api connection issues

### DIFF
--- a/custom_components/vikunja/__init__.py
+++ b/custom_components/vikunja/__init__.py
@@ -3,8 +3,9 @@ from homeassistant import config_entries
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.httpx_client import get_async_client
-from pyvikunja.api import VikunjaAPI
+from pyvikunja.api import VikunjaAPI, APIError
 
 from .const import (
     DOMAIN,
@@ -50,9 +51,9 @@ async def async_setup_entry(hass, entry):
 
     try:
         await vikunja_api.ping()
-    except httpx.HTTPError as e:
+    except (httpx.HTTPError, APIError) as e:
         LOGGER.error(f"Error setting up Vikunja at {vikunja_api.web_ui_link}: {e}")
-        raise e
+        raise ConfigEntryNotReady from e
 
     coordinator = VikunjaDataUpdateCoordinator(hass, entry, vikunja_api, secs_interval)
     await coordinator.async_config_entry_first_refresh()

--- a/custom_components/vikunja/coordinator.py
+++ b/custom_components/vikunja/coordinator.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 import async_timeout
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.core import HomeAssistant
-from pyvikunja.api import VikunjaAPI
+from pyvikunja.api import VikunjaAPI, APIError
 
 from custom_components.vikunja import LOGGER
 from custom_components.vikunja.const import (
@@ -107,6 +107,9 @@ class VikunjaDataUpdateCoordinator(DataUpdateCoordinator):
                         await remove_project_entities(self._hass, self._config_id, project_id)
 
                 return result
+        except APIError as e:
+            LOGGER.debug(f"API Error fetching data from Vikunja: {e}")
+            raise UpdateFailed(f"API Error: {e}") from e
         except Exception as e:
-            LOGGER.error(f"Error fetching data from Vikunja API: {e}")
-            raise e
+            LOGGER.debug(f"Unexpected error fetching data from Vikunja API: {e}")
+            raise UpdateFailed(f"Unexpected error: {e}") from e

--- a/custom_components/vikunja/manifest.json
+++ b/custom_components/vikunja/manifest.json
@@ -8,7 +8,7 @@
     "@joeShuff"
   ],
   "requirements": [
-    "pyvikunja==0.22"
+    "pyvikunja==0.23"
   ],
   "config_flow": true,
   "integration_type": "service",


### PR DESCRIPTION
fixes #39 in combination with https://github.com/joeShuff/pyvikunja/pull/6

- includes raising of `ConfigEntryNotReady` which handles connection issues during HA startup (keeps trying to reconnect)
- includes raising of `UpdateFailed` to keep trying to connect in case of connection issues (and will not remove existing projects/entites)

i didn't update the version in the manifest, since you have a GitHub action for this. Only requirements version was adapted