### PR TITLE
Import task labels on task read

### DIFF
--- a/custom_components/vikunja/sensor.py
+++ b/custom_components/vikunja/sensor.py
@@ -13,7 +13,6 @@ def get_sensors_for_task(coordinator, base_url, task_id):
         VikunjaTaskDescriptionSensor(coordinator, base_url, task_id),
         VikunjaTaskDueDateSensor(coordinator, base_url, task_id),
         VikunjaTaskPrioritySensor(coordinator, base_url, task_id),
-        VikunjaTaskAssigneeSensor(coordinator, base_url, task_id)
         VikunjaTaskAssigneeSensor(coordinator, base_url, task_id),
         VikunjaTaskLabelsSensor(coordinator, base_url, task_id),
     ]

--- a/custom_components/vikunja/sensor.py
+++ b/custom_components/vikunja/sensor.py
@@ -14,6 +14,8 @@ def get_sensors_for_task(coordinator, base_url, task_id):
         VikunjaTaskDueDateSensor(coordinator, base_url, task_id),
         VikunjaTaskPrioritySensor(coordinator, base_url, task_id),
         VikunjaTaskAssigneeSensor(coordinator, base_url, task_id)
+        VikunjaTaskAssigneeSensor(coordinator, base_url, task_id),
+        VikunjaTaskLabelsSensor(coordinator, base_url, task_id),
     ]
 
 

--- a/custom_components/vikunja/sensors/TaskSensors.py
+++ b/custom_components/vikunja/sensors/TaskSensors.py
@@ -368,11 +368,16 @@ class VikunjaTaskLabelsSensor(VikunjaTaskEntity, SensorEntity):
     @property
     def extra_state_attributes(self):
         """Expose full label detail for use in automations and templates."""
-        labels = sorted(self.task.labels, key=lambda label: label.title)
+        labels = sorted(self.task.labels, key=lambda label: label.id)
         return {
-            "label_ids": [label.id for label in labels],
-            "label_titles": [label.title for label in labels],
-            "label_colors": [label.hex_color for label in labels],
+            "labels": [
+                {
+                    "id": label.id,
+                    "title": label.title,
+                    "color": label.hex_color,
+                }
+                for label in labels
+            ]
         }
 
     @property

--- a/custom_components/vikunja/sensors/TaskSensors.py
+++ b/custom_components/vikunja/sensors/TaskSensors.py
@@ -345,3 +345,41 @@ class VikunjaTaskAssigneeSensor(VikunjaTaskEntity, SensorEntity):
     @property
     def unique_id(self) -> str:
         return self.id_prefix() + "_assignees"
+
+class VikunjaTaskLabelsSensor(VikunjaTaskEntity, SensorEntity):
+    """Representation of a Vikunja Task labels sensor."""
+
+    def __init__(self, coordinator, base_url, task_id):
+        super().__init__(coordinator, base_url, task_id)
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return f"{self.name_prefix()} Labels"
+
+    @property
+    def state(self):
+        """Return a comma-separated list of label titles (max 255 chars)."""
+        if self.task.labels:
+            titles = sorted(label.title for label in self.task.labels)
+            return (", ".join(titles))[:255]
+        return "No labels"
+
+    @property
+    def extra_state_attributes(self):
+        """Expose full label detail for use in automations and templates."""
+        labels = sorted(self.task.labels, key=lambda label: label.title)
+        return {
+            "label_ids": [label.id for label in labels],
+            "label_titles": [label.title for label in labels],
+            "label_colors": [label.hex_color for label in labels],
+        }
+
+    @property
+    def icon(self):
+        """Icon for the sensor."""
+        return "mdi:tag-multiple"
+
+    @property
+    def unique_id(self) -> str:
+        return self.id_prefix() + "_labels"


### PR DESCRIPTION
Creates a sensor per task to hold labels. Set to 'no labels' if nothing returns. 

[Discussion](https://github.com/joeShuff/vikunja-homeassistant/issues/57)