### PR TITLE
fix fetching ssl config

### DIFF
--- a/custom_components/vikunja/__init__.py
+++ b/custom_components/vikunja/__init__.py
@@ -39,7 +39,7 @@ async def async_setup_entry(hass, entry):
     base_url = entry.data.get(CONF_BASE_URL) or ""
     token = entry.data.get(CONF_TOKEN) or ""
     secs_interval = entry.data.get(CONF_SECS_INTERVAL) or 60
-    strict_ssl = entry.data.get(CONF_STRICT_SSL) or True
+    strict_ssl = entry.data.get(CONF_STRICT_SSL, True)
 
     if not base_url or not token:
         LOGGER.error("Base URL or token is missing")


### PR DESCRIPTION
This logic was broken, `strict_ssl` was basically impossible to turn off because "anything OR true" will always be true.

Changed to logic with `True` as the default if a config item doesn't exist.

Verified in my dev environment using logs to show the evaluated value of `strict_ssl`